### PR TITLE
(feature) Added default project name

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -79,6 +79,7 @@ export async function promptForProjectDetails(args: string) {
         type: "input",
         name: "projectName",
         message: "Please specify a name for your project: ",
+        default: 'my-web3-project'
       },
     ]);
     console.log("Creating project with name:", projectName);


### PR DESCRIPTION
To be able to run the scaffold command without any parameters like so:

```bash
npx @consensys/create-web3-template
```

I propose adding a default project name.